### PR TITLE
docs: add GitHub link to the `package.json` for `npm` website support

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,5 +88,12 @@
 		"commitizen": {
 			"path": "./node_modules/cz-conventional-changelog"
 		}
-	}
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/NestCrafts/nestjs-minio.git"
+	},
+	"bugs": {
+		"url": "https://github.com/NestCrafts/nestjs-minio/issues"
+	  }
 }


### PR DESCRIPTION
I added a segment of the repository to the `package.json` file for better linked to the npm site

![Screenshot 2024-08-02 at 18 59 20](https://github.com/user-attachments/assets/97cb8b33-2d67-4530-abca-89d85ab2905f)
