### PR TITLE
docs(readme): Fix syntax in 'Initialize MinIO Client' code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ import { NestMinioModule } from '../nest-minio.module';
 @Module({
   controllers: [NestMinioClientController],
   imports: [
-    NestMinioModule.register(
+    NestMinioModule.register({
       isGlobal: true,
-      {
       endPoint: 'play.min.io',
       port: 9000,
       useSSL: true,


### PR DESCRIPTION
- Corrected example usage of `NestMinioModule.register` to prevent sytnax error